### PR TITLE
Fix null array offset warning

### DIFF
--- a/shfs.php
+++ b/shfs.php
@@ -175,7 +175,7 @@ if ( !class_exists( 'HeaderAndFooterScripts' ) ) {
 			}
 
 			$shfs_post_meta = get_post_meta( get_the_ID(), '_inpost_head_script', true );
-			if ( is_singular() && '' !== $shfs_post_meta ) {
+			if ( is_singular() && ! empty( $shfs_post_meta ) ) {
 				echo $shfs_post_meta['synth_header_script'], "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}


### PR DESCRIPTION
After updating to version 2.4.2, the following warning is displayed:

<img width="1070" height="340" alt="image" src="https://github.com/user-attachments/assets/f5e4c1d6-7452-4387-9dd0-ebe2cefaadb8" />

The `$shfs_post_meta` variable contains the value `false`.

Fix warning accessing array offset on false by checking if post meta is not empty before accessing its elements.